### PR TITLE
Update and add documentation to say we now require 3.8.0

### DIFF
--- a/docs/sources/faq.md
+++ b/docs/sources/faq.md
@@ -2,22 +2,20 @@ page_title: FAQ
 page_description: Most frequently asked questions.
 page_keywords: faq, questions, documentation, docker
 
-# FAQ
+# Most frequently asked questions
 
-## Most frequently asked questions
-
-### How much does Docker cost?
+## How much does Docker cost?
 
 Docker is 100% free, it is open source, so you can use it without
 paying.
 
-### What open source license are you using?
+## What open source license are you using?
 
 We are using the Apache License Version 2.0, see it here:
 [https://github.com/docker/docker/blob/master/LICENSE](
 https://github.com/docker/docker/blob/master/LICENSE)
 
-### Does Docker run on Mac OS X or Windows?
+## Does Docker run on Mac OS X or Windows?
 
 Not at this time, Docker currently only runs on Linux, but you can use
 VirtualBox to run Docker in a virtual machine on your box, and get the
@@ -26,14 +24,14 @@ and [*Microsoft Windows*](../installation/windows/#windows) installation
 guides. The small Linux distribution boot2docker can be run inside virtual
 machines on these two operating systems.
 
-### How do containers compare to virtual machines?
+## How do containers compare to virtual machines?
 
 They are complementary. VMs are best used to allocate chunks of
 hardware resources. Containers operate at the process level, which
 makes them very lightweight and perfect as a unit of software
 delivery.
 
-### What does Docker add to just plain LXC?
+## What does Docker add to just plain LXC?
 
 Docker is not a replacement for LXC. "LXC" refers to capabilities of
 the Linux kernel (specifically namespaces and control groups) which
@@ -119,18 +117,18 @@ functionalities:
    establishing itself as the standard for container-based
    tooling.
 
-### What is different between a Docker container and a VM?
+## What is different between a Docker container and a VM?
 
 There's a great StackOverflow answer [showing the differences](
 http://stackoverflow.com/questions/16047306/how-is-docker-io-different-from-a-normal-virtual-machine).
 
-### Do I lose my data when the container exits?
+## Do I lose my data when the container exits?
 
 Not at all! Any data that your application writes to disk gets preserved
 in its container until you explicitly delete the container. The file
 system for the container persists even after the container halts.
 
-### How far do Docker containers scale?
+## How far do Docker containers scale?
 
 Some of the largest server farms in the world today are based on
 containers. Large web deployments like Google and Twitter, and platform
@@ -138,7 +136,7 @@ providers such as Heroku and dotCloud all run on container technology,
 at a scale of hundreds of thousands or even millions of containers
 running in parallel.
 
-### How do I connect Docker containers?
+## How do I connect Docker containers?
 
 Currently the recommended way to link containers is via the link
 primitive. You can see details of how to [work with links
@@ -147,7 +145,7 @@ here](/userguide/dockerlinks).
 Also of useful when enabling more flexible service portability is the
 [Ambassador linking pattern](/articles/ambassador_pattern_linking/).
 
-### How do I run more than one process in a Docker container?
+## How do I run more than one process in a Docker container?
 
 Any capable process supervisor such as [http://supervisord.org/](
 http://supervisord.org/), runit, s6, or daemontools can do the trick.
@@ -156,38 +154,57 @@ to run additional processes. As long as the processor manager daemon continues
 to run, the container will continue to as well. You can see a more substantial
 example [that uses supervisord here](/articles/using_supervisord/).
 
-### What platforms does Docker run on?
+## What platforms does Docker run on?
 
-Linux:
+Docker uses Linux Kernel features that are present in version 3.8.0, and 
+(and the heavily patched RHEL6 based 2.6.32 used by it and its derivatives).
+The Docker daemon will stop with an error if you try to start it on
+a system running an older Kernel:
 
- - Ubuntu 12.04, 13.04 et al
- - Fedora 19/20+
- - RHEL 6.5+
- - Centos 6+
- - Gentoo
- - ArchLinux
- - openSUSE 12.3+
- - CRUX 3.0+
 
-Cloud:
+    ERROR: You are running linux kernel version 3.2.10, which will be unstable 
+    while running docker. Kernels older than 3.8.0 are unsupported. 
+    Please upgrade your kernel to 3.8.0 or newer.
 
- - Amazon EC2
- - Google Compute Engine
- - Rackspace
 
-### How do I report a security issue with Docker?
+### Linux distributions:
+
+ - [Ubuntu 12.04, 13.04+](installation/ubuntulinux.md)
+ - [Debian Jessie 8.0](installation/debian.md)
+ - [Fedora 19/20+](installation/fedora.md)
+ - [RHEL 6.5+](installation/rhel.md)
+ - [Centos 6+](installation/centos.md)
+ - [Gentoo](installation/gentoolinux.md)
+ - [ArchLinux](installation/archlinux.md)
+ - [openSUSE 12.3+](installation/openSUSE.md)
+ - [CRUX 3.0+](installation/cruxlinux.md)
+ - [FrugalWare](installation/frugalware.md)
+
+### Cloud Linux providers:
+
+ - [Amazon EC2](installation/amazon.md)
+ - [Google Compute Engine](installation/google.md)
+ - [Rackspace](installation/rackspace.md)
+ - [IBM Softlayer](installation/softlayer.md)
+ 
+### Boot2Docker via Virtual Machine
+
+ - [OS X](installation/mac.md)
+ - [MS Windows](installation/windows.md)
+
+## How do I report a security issue with Docker?
 
 You can learn about the project's security policy
 [here](https://www.docker.com/security/) and report security issues to
 this [mailbox](mailto:security@docker.com).
 
-### Why do I need to sign my commits to Docker with the DCO?
+## Why do I need to sign my commits to Docker with the DCO?
 
 Please read [our blog post](
 http://blog.docker.com/2014/01/docker-code-contributions-require-developer-certificate-of-origin/)
 on the introduction of the DCO.
 
-### When building an image, should I prefer system libraries or bundled ones?
+## When building an image, should I prefer system libraries or bundled ones?
 
 *This is a summary of a discussion on the [docker-dev mailing list](
 https://groups.google.com/forum/#!topic/docker-dev/L2RBSPDu1L0).*
@@ -225,7 +242,7 @@ Downloading and installing an "all-in-one" .deb or .rpm sounds great at first,
 except if you have no way to figure out that it contains a copy of the
 OpenSSL library vulnerable to the [Heartbleed](http://heartbleed.com/) bug.
 
-### Why is `DEBIAN_FRONTEND=noninteractive` discouraged in Dockerfiles?
+## Why is `DEBIAN_FRONTEND=noninteractive` discouraged in Dockerfiles?
 
 When building Docker images on Debian and Ubuntu you may have seen errors like:
 
@@ -257,12 +274,12 @@ If you *really* need to change its setting, make sure to change it
 back to its [default value](https://www.debian.org/releases/stable/i386/ch05s03.html.en) 
 afterwards.
 
-### Can I help by adding some questions and answers?
+## Can I help by adding some questions and answers?
 
 Definitely! You can fork [the repo](https://github.com/docker/docker) and
 edit the documentation sources.
 
-### Where can I find more answers?
+## Where can I find more answers?
 
 You can find more answers on:
 

--- a/docs/sources/installation/binaries.md
+++ b/docs/sources/installation/binaries.md
@@ -32,7 +32,7 @@ runtime:
 Docker in daemon mode has specific kernel requirements. For details,
 check your distribution in [*Installation*](../#installation-list).
 
-In general, a 3.8 Linux kernel (or higher) is preferred, as some of the
+A 3.8 Linux kernel (or higher) is required, as some of the
 prior versions have known issues that are triggered by Docker.
 
 Note that Docker also has a client mode, which can run on virtually any

--- a/docs/sources/installation/ubuntulinux.md
+++ b/docs/sources/installation/ubuntulinux.md
@@ -79,7 +79,7 @@ This installation path should work at all times.
 
 **Linux kernel 3.8**
 
-Due to a bug in LXC, Docker works best on the 3.8 kernel. Precise comes
+Due to a bug in LXC, Docker requires at minimum a 3.8 kernel. Precise comes
 with a 3.2 kernel, so we need to upgrade it. The kernel you'll install
 when following these steps comes with AUFS built in. We also include the
 generic headers to enable packages that depend on them, like ZFS and the


### PR DESCRIPTION
this is for https://github.com/docker/docker/pull/7681

Docker-DCO-1.1-Signed-off-by: SvenDowideit SvenDowideit@home.org.au (github: SvenDowideit)
